### PR TITLE
power: Drop default POWER_HINT_INTERACTION routine

### DIFF
--- a/power-helper.c
+++ b/power-helper.c
@@ -279,14 +279,6 @@ void power_hint(power_hint_t hint, void *data)
         case POWER_HINT_VR_MODE:
             ALOGI("VR mode power hint not handled in power_hint_override");
         break;
-        case POWER_HINT_INTERACTION:
-        {
-            int resources[] = {0x702, 0x20F, 0x30F};
-            int duration = 3000;
-
-            interaction(duration, sizeof(resources)/sizeof(resources[0]), resources);
-        }
-        break;
         case POWER_HINT_VIDEO_ENCODE:
             process_video_encode_hint(data);
         break;


### PR DESCRIPTION
 * These boost resources were introduced years ago and are no longer
   suitable for modern SoCs. Each SoC should implement its own boost
   resource in either platform specific power HAL source file or perf
   HAL.
 * Starting from LineageOS 15.1, recent SoCs no longer handle
   POWER_HINT_INTERACTION in the power HAL, so power_hint_override
   returns HINT_NONE and the default routine is always executed. E.g, on
   msm8996 little cluster is always boosted to max frequency on touch,
   which causes a huge battery drain.
 * As a bonus, the "Failed to apply optimization" errors are gone.

Change-Id: I322f23f40fc5da7485f2c7a6cf8ee952d0fb94c6
Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>